### PR TITLE
Apply admin house style colours to UI

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,27 @@
     <meta charset="utf-8">
     <title>ExtraFabulousReports</title>
     <link rel="stylesheet" href="https://cdn.simplecss.org/simple.min.css">
+    {# Inline style block applies administrator-defined colours #}
+    {% if house_style %}
+    <style>
+    :root {
+        /* Expose colours as CSS variables for easy reuse */
+        --primary-color: {{ house_style.primary_color }};
+        --secondary-color: {{ house_style.secondary_color }};
+    }
+    header, nav a, button {
+        /* Use primary colour for main chrome elements */
+        background-color: var(--primary-color);
+        color: var(--secondary-color);
+    }
+    body {
+        background-color: var(--secondary-color);
+    }
+    a {
+        color: var(--primary-color);
+    }
+    </style>
+    {% endif %}
 </head>
 <body>
 <header>

--- a/templates/style.html
+++ b/templates/style.html
@@ -2,6 +2,14 @@
 {% block content %}
 <h2>House Style</h2>
 <form method="post">
+    <!-- Colour pickers let the admin define the UI theme -->
+    <label>Primary colour
+        <input type="color" name="primary_color" value="{{ style.primary_color }}">
+    </label>
+    <label>Secondary colour
+        <input type="color" name="secondary_color" value="{{ style.secondary_color }}">
+    </label>
+    <!-- Arbitrary LaTeX preamble or additional configuration -->
     <textarea name="style" rows="20">{{ style.style }}</textarea>
     <button type="submit">Save</button>
 </form>


### PR DESCRIPTION
## Summary
- Add primary and secondary colour fields to HouseStyle and expose them to templates
- Allow admins to configure colours and apply them throughout the app

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e5c14e43c83288f776ee1ca5f5398