### PR TITLE
Add instructions and help pages with navbar links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ ExtraFabulousReports is a lightweight collaborative web application for authorin
 - Administrator role for configuring the LaTeX house style
 - Create, edit and compile LaTeX documents into PDFs
 - Upload images for use in documents
+- Dedicated instructions and help pages linked in the navigation bar
 
 ## Quick start
 1. Install dependencies:

--- a/app.py
+++ b/app.py
@@ -144,6 +144,22 @@ def logout():
     return redirect(url_for('login'))
 
 # ----------------------------------------------------------------------------
+# Informational routes
+# ----------------------------------------------------------------------------
+
+@app.route('/instructions')
+def instructions():
+    """Display general usage instructions."""
+    # Provide a simple page outlining how to use the application
+    return render_template('instructions.html')
+
+@app.route('/help')
+def help_page():
+    """Display a help and troubleshooting page."""
+    # Basic guidance and contact information for end users
+    return render_template('help.html')
+
+# ----------------------------------------------------------------------------
 # Document management routes
 # ----------------------------------------------------------------------------
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -39,15 +39,21 @@
     <div class="container-fluid">
         <a class="navbar-brand text-light" href="{{ url_for('list_documents') }}">ExtraFabulousReports</a>
         <div class="collapse navbar-collapse">
-            {% if current_user.is_authenticated %}
             <ul class="navbar-nav ms-auto">
+                {# Links to general information pages available to all users #}
+                <li class="nav-item"><a class="nav-link text-light" href="{{ url_for('instructions') }}">Instructions</a></li>
+                <li class="nav-item"><a class="nav-link text-light" href="{{ url_for('help_page') }}">Help</a></li>
+                {% if current_user.is_authenticated %}
                 <li class="nav-item"><a class="nav-link text-light" href="{{ url_for('list_documents') }}">Documents</a></li>
                 {% if current_user.is_admin %}
                 <li class="nav-item"><a class="nav-link text-light" href="{{ url_for('edit_style') }}">House Style</a></li>
                 {% endif %}
                 <li class="nav-item"><a class="nav-link text-light" href="{{ url_for('logout') }}">Logout</a></li>
+                {% else %}
+                <li class="nav-item"><a class="nav-link text-light" href="{{ url_for('login') }}">Login</a></li>
+                <li class="nav-item"><a class="nav-link text-light" href="{{ url_for('register') }}">Register</a></li>
+                {% endif %}
             </ul>
-            {% endif %}
         </div>
     </div>
 </nav>

--- a/templates/help.html
+++ b/templates/help.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="mb-3">Help</h2>
+{# Offer troubleshooting advice and contact information #}
+<p>If you run into problems while using ExtraFabulousReports, try the following:</p>
+<ul>
+    <li>Review the <a href="{{ url_for('instructions') }}">instructions</a> for guidance on common tasks.</li>
+    <li>Check that your LaTeX compiles locally if a document fails to compile on the server.</li>
+    <li>Contact your system administrator for account or configuration issues.</li>
+</ul>
+<p>Additional support may be provided by your team or organisation.</p>
+{% endblock %}

--- a/templates/instructions.html
+++ b/templates/instructions.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="mb-3">Instructions</h2>
+{# Provide step-by-step guidance for new users #}
+<p>This application lets teams create and manage LaTeX reports collaboratively. Follow these steps to get started:</p>
+<ul>
+    <li>Use the <strong>Register</strong> link to create an account then log in.</li>
+    <li>Navigate to the <strong>Documents</strong> page to create or edit reports.</li>
+    <li>Upload images using the editor's upload form and reference them in your LaTeX.</li>
+    <li>Administrators can fine-tune the LaTeX look and feel on the <strong>House Style</strong> page.</li>
+</ul>
+{% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -24,3 +24,18 @@ def test_register_and_login(client):
     # Login
     response = client.post('/login', data={'username': 'alice', 'password': 'pw'}, follow_redirects=True)
     assert b'Your Documents' in response.data
+
+
+def test_instructions_and_help_pages(client):
+    """Ensure the informational pages render without authentication."""
+    assert b'Instructions' in client.get('/instructions').data
+    assert b'Help' in client.get('/help').data
+
+
+def test_navbar_links_visible_after_login(client):
+    """After logging in, the navigation bar should expose instruction and help links."""
+    client.post('/register', data={'username': 'bob', 'password': 'pw'})
+    response = client.post('/login', data={'username': 'bob', 'password': 'pw'}, follow_redirects=True)
+    # The document list page should include the navigation links
+    assert b'Instructions' in response.data
+    assert b'Help' in response.data


### PR DESCRIPTION
## Summary
- add instructions and help routes and templates
- expose instructions and help links in the navigation bar
- test informational pages and navbar visibility

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e611da35c832889cb65d64772f702