### PR TITLE
Add figure caption and reference markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ ExtraFabulousReports is a lightweight collaborative web application for authorin
 - Create, edit and compile LaTeX documents into PDFs
 - Upload images for use in documents
 - Dedicated instructions and help pages linked in the navigation bar
+- Simple markup for figures with captions and cross-references
 
 ## Quick start
 1. Install dependencies:

--- a/templates/instructions.html
+++ b/templates/instructions.html
@@ -7,6 +7,11 @@
     <li>Use the <strong>Register</strong> link to create an account then log in.</li>
     <li>Navigate to the <strong>Documents</strong> page to create or edit reports.</li>
     <li>Upload images using the editor's upload form and reference them in your LaTeX.</li>
+    <li>
+        Include figures with captions using
+        <code>{{'{{figure:path|caption|label}}'}}</code> and reference them
+        later via <code>{{'{{ref:label}}'}}</code>.
+    </li>
     <li>Administrators can fine-tune the LaTeX look and feel on the <strong>House Style</strong> page.</li>
 </ul>
 {% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,7 +5,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import pytest
-from app import app, db, Document
+from app import app, db, Document, render_figures_and_refs
 
 @pytest.fixture
 def client():
@@ -39,6 +39,18 @@ def test_navbar_links_visible_after_login(client):
     # The document list page should include the navigation links
     assert b'Instructions' in response.data
     assert b'Help' in response.data
+
+
+def test_render_figures_and_refs():
+    """Custom figure and reference syntax expands to LaTeX code."""
+    sample = (
+        "See {{ref:sample}} for details.\n"
+        "{{figure:static/uploads/img.png|Example caption|sample}}"
+    )
+    processed = render_figures_and_refs(sample)
+    assert "\\includegraphics{static/uploads/img.png}" in processed
+    assert "\\caption{Example caption}" in processed
+    assert "Figure \\ref{fig:sample}" in processed
 
 
 def test_delete_document(client):


### PR DESCRIPTION
## Summary
- add helper to expand custom figure and reference tags into LaTeX
- document new figure markup syntax for users
- test figure caption and reference rendering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e6a233fd8832892780301ea18c24b