### PR TITLE
Add equation builder helper with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ ExtraFabulousReports is a lightweight collaborative web application for authorin
 - Upload images for use in documents
 - Dedicated instructions and help pages linked in the navigation bar
 - Simple markup for figures with captions and cross-references
+- Helper to programmatically build LaTeX equation blocks
 
 ## Quick start
 1. Install dependencies:
@@ -26,4 +27,23 @@ ExtraFabulousReports is a lightweight collaborative web application for authorin
 Run the minimal test suite with:
 ```bash
 python -m pytest
+```
+
+## Equation builder example
+Generate a LaTeX equation environment from Python code:
+
+```python
+from app import build_equation
+
+latex = build_equation("E", "mc^2", label="mass_energy")
+print(latex)
+```
+
+This prints:
+
+```
+\begin{equation}
+E = mc^2
+\label{eq:mass_energy}
+\end{equation}
 ```

--- a/app.py
+++ b/app.py
@@ -133,6 +133,42 @@ def render_figures_and_refs(text: str) -> str:
 
     return text
 
+def build_equation(lhs: str, rhs: str, label: str | None = None) -> str:
+    """Construct a LaTeX equation environment from its components.
+
+    Parameters
+    ----------
+    lhs:
+        The left-hand side of the equation.
+    rhs:
+        The right-hand side of the equation.
+    label:
+        Optional label for cross-referencing. When provided, a ``\\label``
+        statement with an ``eq:`` prefix is included.
+
+    Returns
+    -------
+    str
+        A complete LaTeX ``equation`` environment containing the expression
+        and optional label.
+    """
+
+    # Combine the left and right expressions into a single equation string.
+    equation = f"{lhs} = {rhs}"
+
+    # Build up the lines of the LaTeX ``equation`` environment.
+    lines = ["\\begin{equation}", equation]
+
+    # If a label was supplied, append it using the common ``eq:`` prefix so
+    # writers can reference the equation later.
+    if label:
+        lines.append(f"\\label{{eq:{label}}}")
+
+    # Close the environment. Joining the list with newlines keeps the output
+    # readable when the LaTeX is inspected directly or embedded in templates.
+    lines.append("\\end{equation}")
+    return "\n".join(lines)
+
 # ----------------------------------------------------------------------------
 # Flask-Login configuration
 # ----------------------------------------------------------------------------

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,7 +5,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import pytest
-from app import app, db, Document, render_figures_and_refs
+from app import app, db, Document, render_figures_and_refs, build_equation
 
 @pytest.fixture
 def client():
@@ -51,6 +51,17 @@ def test_render_figures_and_refs():
     assert "\\includegraphics{static/uploads/img.png}" in processed
     assert "\\caption{Example caption}" in processed
     assert "Figure \\ref{fig:sample}" in processed
+
+
+def test_build_equation():
+    """Equation builder should assemble a full LaTeX equation block."""
+    result = build_equation("E", "mc^2", label="mass_energy")
+    # The environment lines should wrap the expression
+    assert "\\begin{equation}" in result
+    assert "E = mc^2" in result
+    # The optional label is prefixed with ``eq:`` for consistency
+    assert "\\label{eq:mass_energy}" in result
+    assert result.strip().endswith("\\end{equation}")
 
 
 def test_delete_document(client):


### PR DESCRIPTION
## Summary
- add `build_equation` helper to generate LaTeX equation blocks with optional labels
- document and demonstrate the helper in the README
- cover equation builder with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e7270933083288a921d27ed77266c