### PR TITLE
Document cross-platform Flask CLI invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ ExtraFabulousReports is a lightweight collaborative web application for authorin
    ```
 2. Initialize the database and run the development server:
    ```bash
-   flask --app app.py init-db
-   flask --app app.py run
+   python -m flask --app app.py init-db
+   python -m flask --app app.py run
    ```
+   The `python -m flask` form ensures the CLI is available even if the `flask`
+   executable is not on your system's `PATH`, which is common on Windows.
 3. Open your browser at http://localhost:5000 and create the first user. The first registered account automatically becomes the administrator.
 
 ## Tests


### PR DESCRIPTION
## Summary
- Update setup instructions to use `python -m flask`, ensuring the CLI works even when `flask` isn't on PATH.

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e86cc2c008328b1fcba7aa3ced00d