### PR TITLE
Add Raspberry Pi helper script and venv instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,35 @@ ExtraFabulousReports is a lightweight collaborative web application for authorin
 - Helper to programmatically build LaTeX equation blocks
 
 ## Quick start
-1. Install dependencies:
-   ```bash
-   python -m pip install -r requirements.txt
-   ```
-2. Initialize the database and run the development server:
-   ```bash
-   python -m flask --app app.py init-db
-   python -m flask --app app.py run
-   ```
-   The `python -m flask` form ensures the CLI is available even if the `flask`
-   executable is not on your system's `PATH`, which is common on Windows.
-3. Open your browser at http://localhost:5000 and create the first user. The first registered account automatically becomes the administrator.
+1. Create and activate a virtual environment:
+    ```bash
+    python3 -m venv venv
+    source venv/bin/activate
+    ```
+2. Install dependencies:
+    ```bash
+    pip install -r requirements.txt
+    ```
+3. Initialize the database and run the development server:
+    ```bash
+    python -m flask --app app.py init-db
+    python -m flask --app app.py run
+    ```
+    The `python -m flask` form ensures the CLI is available even if the `flask`
+    executable is not on your system's `PATH`, which is common on Windows.
+4. Open your browser at http://localhost:5000 and create the first user. The first registered account automatically becomes the administrator.
+
+## Raspberry Pi helper script
+
+The `efr.sh` script simplifies setup on a Raspberry Pi by creating a virtual
+environment, installing dependencies and starting the server:
+
+```bash
+./efr.sh [-p PORT] [--prod]
+```
+
+- `-p` or `--port` selects the listening port (default `5000`).
+- `-P` or `--prod` runs in production mode with debug disabled.
 
 ## Tests
 Run the minimal test suite with:

--- a/efr.sh
+++ b/efr.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# efr.sh - Helper script to run ExtraFabulousReports on a Raspberry Pi.
+# This script creates/activates a Python virtual environment, installs
+# dependencies and starts the Flask server.
+
+set -e  # Exit immediately on error.
+
+PORT=5000       # Default port for the web server.
+DEBUG=true      # Debug mode is enabled by default for development.
+
+# ---------------------------------------------------------------------------
+# Parse command-line arguments
+#   -p or --port <port>: choose a custom port
+#   -P or --prod:       run in production mode (disables debug)
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p|--port)
+      PORT="$2"
+      shift 2
+      ;;
+    -P|--prod)
+      DEBUG=false
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [-p PORT] [--prod]"
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Set up the virtual environment if it does not already exist. The venv
+# directory is created once and reused on subsequent runs.
+# ---------------------------------------------------------------------------
+if [[ ! -d venv ]]; then
+  python3 -m venv venv
+fi
+
+# Activate the virtual environment so that Python and pip use the isolated
+# environment. shellcheck disable=SC1091 tells linting tools the source path is
+# dynamic and should not raise an error.
+# shellcheck source=/dev/null
+source venv/bin/activate
+
+# Install required dependencies inside the virtual environment. This is safe to
+# run multiple times because pip skips packages that are already installed.
+pip install -r requirements.txt
+
+# ---------------------------------------------------------------------------
+# Launch the Flask development server. In production mode we omit the --debug
+# flag to disable the reloader and debugger.
+# ---------------------------------------------------------------------------
+if [[ "$DEBUG" == true ]]; then
+  python -m flask --app app run --host 0.0.0.0 --port "$PORT" --debug
+else
+  python -m flask --app app run --host 0.0.0.0 --port "$PORT"
+fi


### PR DESCRIPTION
## Summary
- document virtual environment creation in README
- add `efr.sh` script to automate setup and run the app on Raspberry Pi

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e894a58048328b48e0d86eca76df9