### PR TITLE
Add network-aware server launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,55 @@ ExtraFabulousReports is a lightweight collaborative web application for authorin
 - Simple markup for figures with captions and cross-references
 - Helper to programmatically build LaTeX equation blocks
 
-## Quick start
-1. Install dependencies:
+## Setup
+
+The project supports both Windows and Linux/Raspberry Pi systems. A small
+setup script is provided for Unix-like platforms to make installation
+straightforward.
+
+### Linux/macOS/Raspberry Pi
+1. **Create a virtual environment and install dependencies**:
    ```bash
-   python -m pip install -r requirements.txt
+   ./setup_extrafabulous_reports_env.sh
    ```
-2. Initialize the database and run the development server:
+   This script creates a `venv` folder and installs everything from
+   `requirements.txt`.
+2. **Initialize the database and run the server**:
    ```bash
    python -m flask --app app.py init-db
-   # The custom run-server command binds to all interfaces for network access.
+   ./run_extrafabulous_reports_server.sh
+   ```
+
+### Windows
+1. **Create a virtual environment**:
+   ```powershell
+   py -3 -m venv venv
+   venv\Scripts\activate
+   pip install -r requirements.txt
+   ```
+2. **Initialize the database and run the server**:
+   ```powershell
+   python -m flask --app app.py init-db
    python -m flask --app app.py run-server
    ```
-   The `python -m flask` form ensures the CLI is available even if the `flask`
-   executable is not on your system's `PATH`, which is common on Windows.
-3. Open your browser at http://localhost:5000 (or replace `localhost` with the server's IP address from another device) and create the first user. The first registered account automatically becomes the administrator.
+
+## Running the server
+
+The custom `run-server` command exposes the app on the network. You may select
+the port and whether to use the production-ready Waitress server.
+
+```bash
+# Development server on port 8000
+./run_extrafabulous_reports_server.sh --port 8000
+
+# Production server on default port 5000
+./run_extrafabulous_reports_server.sh --prod
+```
+
+On Windows use `python -m flask --app app.py run-server` in place of the shell
+script.
+
+When the server starts it prints the full URL so users know where to connect.
 
 ## Tests
 Run the minimal test suite with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask-Login>=0.6.2
 Flask-SQLAlchemy>=3.0.5
 Werkzeug>=2.2
 pytest>=7
+waitress>=2.1.2

--- a/run_extrafabulous_reports_server.sh
+++ b/run_extrafabulous_reports_server.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Convenience script to launch the ExtraFabulousReports server with network access.
+# Additional arguments such as --port or --prod are forwarded to the Flask CLI.
+
+python -m flask --app app.py run-server "$@"

--- a/setup_extrafabulous_reports_env.sh
+++ b/setup_extrafabulous_reports_env.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Set up a Python virtual environment and install dependencies for ExtraFabulousReports.
+
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+printf "Environment ready. Activate with 'source venv/bin/activate'\n"


### PR DESCRIPTION
## Summary
- add configurable `start_app` helper with production option
- expose `run-server` CLI with host/port flags and Waitress support
- document setup and add helper scripts for virtual env and server launch

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891288af4c083289054228a6cc8bf08