### PR TITLE
Add platform-specific launch scripts with configurable port and mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,43 @@ ExtraFabulousReports is a lightweight collaborative web application for authorin
 - Helper to programmatically build LaTeX equation blocks
 
 ## Quick start
-1. Install dependencies:
+Follow these steps to get ExtraFabulousReports running. Commands are provided
+for both Windows PowerShell and Raspberry Pi/Linux terminals.
+
+1. **Create a virtual environment**
+   - *Windows*:
+     ```powershell
+     python -m venv venv
+     .\venv\Scripts\Activate.ps1
+     ```
+   - *Raspberry Pi/Linux*:
+     ```bash
+     python3 -m venv venv
+     source venv/bin/activate
+     ```
+2. **Install dependencies**
    ```bash
-   python -m pip install -r requirements.txt
+   pip install -r requirements.txt
    ```
-2. Initialize the database and run the development server:
+3. **Initialize the database**
    ```bash
    python -m flask --app app.py init-db
-   # The custom run-server command binds to all interfaces for network access.
-   python -m flask --app app.py run-server
    ```
-   The `python -m flask` form ensures the CLI is available even if the `flask`
-   executable is not on your system's `PATH`, which is common on Windows.
-3. Open your browser at http://localhost:5000 (or replace `localhost` with the server's IP address from another device) and create the first user. The first registered account automatically becomes the administrator.
+4. **Start the server**
+   - *Windows*:
+     ```powershell
+     .\XFabReps_windows.ps1 -Port 5000
+     ```
+   - *Raspberry Pi/Linux*:
+     ```bash
+     ./XFabReps_rpi.sh -p 5000
+     ```
+   Append `-Production` or `--production` to use a production-ready server.
+   The scripts print a summary so you always know the port and mode.
+
+5. Open your browser at `http://localhost:PORT` (replace `PORT` with your chosen
+   value) and create the first user. The first registered account automatically
+   becomes the administrator.
 
 ## Tests
 Run the minimal test suite with:

--- a/XFabReps_rpi.sh
+++ b/XFabReps_rpi.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Launch ExtraFabulousReports on Raspberry Pi or other Linux systems.
+# Supports optional port selection and production mode.
+
+set -euo pipefail
+
+PORT=5000
+PRODUCTION=0
+
+show_help() {
+    echo "Usage: ./XFabReps_rpi.sh [-p PORT] [--production]"
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p|--port)
+      PORT="$2"
+      shift 2
+      ;;
+    --production)
+      PRODUCTION=1
+      shift
+      ;;
+    -h|--help)
+      show_help
+      ;;
+    *)
+      echo "Unknown option: $1"
+      show_help
+      ;;
+  esac
+done
+
+MODE="development"
+if [[ $PRODUCTION -eq 1 ]]; then
+  MODE="production"
+fi
+
+echo "Starting ExtraFabulousReports on port $PORT in $MODE mode"
+
+if [[ $PRODUCTION -eq 1 ]]; then
+  python3 app.py --port "$PORT" --production
+else
+  python3 app.py --port "$PORT"
+fi

--- a/XFabReps_windows.ps1
+++ b/XFabReps_windows.ps1
@@ -1,0 +1,27 @@
+<#
+.SYNOPSIS
+    Launch ExtraFabulousReports on Windows.
+.DESCRIPTION
+    Starts the web server with optional port and production parameters.
+    Use -Help to display usage information.
+#>
+
+param(
+    [int]$Port = 5000,
+    [switch]$Production,
+    [switch]$Help
+)
+
+if ($Help) {
+    Write-Host "Usage: .\XFabReps_windows.ps1 [-Port <number>] [-Production]" -ForegroundColor Yellow
+    exit 0
+}
+
+$mode = if ($Production) { "production" } else { "development" }
+Write-Host "Starting ExtraFabulousReports on port $Port in $mode mode"
+
+if ($Production) {
+    python app.py --port $Port --production
+} else {
+    python app.py --port $Port
+}

--- a/app.py
+++ b/app.py
@@ -453,6 +453,34 @@ def inject_house_style():
 # ----------------------------------------------------------------------------
 
 if __name__ == '__main__':
-    # Listen on all interfaces to allow access from other machines on the
-    # network during development.
-    app.run(host='0.0.0.0', debug=True)
+    # Allow the user to tweak how the server runs via command-line flags.
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Run the ExtraFabulousReports web application."
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=5000,
+        help="Port number to listen on (default: 5000).",
+    )
+    parser.add_argument(
+        "--production",
+        action="store_true",
+        help="Use a production-ready server instead of Flask's development server.",
+    )
+    args = parser.parse_args()
+
+    # Provide immediate feedback so the user knows how the app is running.
+    mode = "production" if args.production else "development"
+    print(f"Starting ExtraFabulousReports on port {args.port} in {mode} mode")
+
+    # Listen on all interfaces to allow access from other machines on the network.
+    if args.production:
+        # Import Waitress lazily so unit tests and basic dev usage don't require it.
+        from waitress import serve
+
+        serve(app, host='0.0.0.0', port=args.port)
+    else:
+        app.run(host='0.0.0.0', port=args.port, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask-Login>=0.6.2
 Flask-SQLAlchemy>=3.0.5
 Werkzeug>=2.2
 pytest>=7
+waitress>=2.1


### PR DESCRIPTION
## Summary
- allow passing `--port` and `--production` flags when starting the Flask app
- add Windows and Raspberry Pi launch scripts to simplify deployment
- document setup steps for Windows and Linux and list waitress dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891271919bc83289677b58e9d7acc0a