### PR TITLE
Add cross-platform deployment scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,51 +13,58 @@ ExtraFabulousReports is a lightweight collaborative web application for authorin
 
 ## Setup
 
-The project supports both Windows and Linux/Raspberry Pi systems. A small
-setup script is provided for Unix-like platforms to make installation
-straightforward.
+The project supports both Windows and Linux/Raspberry Pi systems. Small helper scripts make installation straightforward.
 
 ### Linux/macOS/Raspberry Pi
 1. **Create a virtual environment and install dependencies**:
    ```bash
-   ./setup_extrafabulous_reports_env.sh
+   ./xfabreps_setup_env.sh
    ```
-   This script creates a `venv` folder and installs everything from
-   `requirements.txt`.
-2. **Initialize the database and run the server**:
+2. **Activate the environment and initialise the database**:
    ```bash
+   source venv/bin/activate
    python -m flask --app app.py init-db
-   ./run_extrafabulous_reports_server.sh
+   ```
+3. **Run the server**:
+   ```bash
+   ./xfabreps_run_server.sh --port 8000   # choose any port you like
    ```
 
 ### Windows
-1. **Create a virtual environment**:
+1. **Create a virtual environment and install dependencies**:
    ```powershell
-   py -3 -m venv venv
-   venv\Scripts\activate
-   pip install -r requirements.txt
+   .\xfabreps_setup_env.ps1
    ```
-2. **Initialize the database and run the server**:
+2. **Activate the environment and initialise the database**:
    ```powershell
+   .\venv\Scripts\Activate.ps1
    python -m flask --app app.py init-db
-   python -m flask --app app.py run-server
+   ```
+3. **Run the server**:
+   ```powershell
+   .\xfabreps_run_server.ps1 -Port 8000   # add -Prod to use Waitress
    ```
 
 ## Running the server
 
-The custom `run-server` command exposes the app on the network. You may select
-the port and whether to use the production-ready Waitress server.
+Both scripts support changing the port and enabling a production-ready Waitress server.
 
 ```bash
 # Development server on port 8000
-./run_extrafabulous_reports_server.sh --port 8000
+./xfabreps_run_server.sh --port 8000
 
 # Production server on default port 5000
-./run_extrafabulous_reports_server.sh --prod
+./xfabreps_run_server.sh --prod
 ```
 
-On Windows use `python -m flask --app app.py run-server` in place of the shell
-script.
+Windows equivalents:
+```powershell
+# Development server on port 8000
+.\xfabreps_run_server.ps1 -Port 8000
+
+# Production server on default port 5000
+.\xfabreps_run_server.ps1 -Prod
+```
 
 When the server starts it prints the full URL so users know where to connect.
 

--- a/run_extrafabulous_reports_server.sh
+++ b/run_extrafabulous_reports_server.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-# Convenience script to launch the ExtraFabulousReports server with network access.
-# Additional arguments such as --port or --prod are forwarded to the Flask CLI.
-
-python -m flask --app app.py run-server "$@"

--- a/setup_extrafabulous_reports_env.sh
+++ b/setup_extrafabulous_reports_env.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-# Set up a Python virtual environment and install dependencies for ExtraFabulousReports.
-
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-printf "Environment ready. Activate with 'source venv/bin/activate'\n"

--- a/xfabreps_run_server.ps1
+++ b/xfabreps_run_server.ps1
@@ -1,0 +1,20 @@
+<#
+Start the ExtraFabulousReports server on Windows.
+
+Usage:
+  .\xfabreps_run_server.ps1 [-Port 8000] [-Prod] [-Host 0.0.0.0]
+
+-Port : TCP port to listen on (default 5000)
+-Prod : Use the production Waitress server if available
+-Host : Interface to bind to (default 0.0.0.0)
+#>
+param(
+    [int]$Port = 5000,
+    [switch]$Prod,
+    [string]$Host = "0.0.0.0"
+)
+
+$cmd = @("python", "app.py", "--host", $Host, "--port", $Port)
+if ($Prod) { $cmd += "--prod" }
+Write-Host "Starting ExtraFabulousReports with command: $($cmd -join ' ')"
+& $cmd

--- a/xfabreps_run_server.sh
+++ b/xfabreps_run_server.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Start the ExtraFabulousReports server on Linux/Raspberry Pi.
+#
+# Usage:
+#   ./xfabreps_run_server.sh [--port PORT] [--prod] [other-flask-args]
+#
+# --port PORT  : TCP port to listen on (default: 5000)
+# --prod       : Use the production Waitress server if installed
+# Any additional arguments are forwarded to the underlying Python app,
+# allowing advanced users to specify options like --host.
+
+set -euo pipefail
+
+PORT=5000          # Default port if --port is not provided
+USE_PROD=0         # Whether to run the production server
+EXTRA_ARGS=()      # Collect any other arguments
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port)
+      PORT="$2"
+      shift 2
+      ;;
+    --prod)
+      USE_PROD=1
+      shift
+      ;;
+    *)
+      EXTRA_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+# Build the Python command dynamically
+CMD=(python app.py --port "$PORT")
+if [[ "$USE_PROD" -eq 1 ]]; then
+  CMD+=("--prod")
+fi
+CMD+=("${EXTRA_ARGS[@]}")
+
+# Echo the command for debugging so users can see what is executed
+printf 'Starting ExtraFabulousReports with command: %s\n' "${CMD[*]}"
+"${CMD[@]}"

--- a/xfabreps_setup_env.ps1
+++ b/xfabreps_setup_env.ps1
@@ -1,0 +1,15 @@
+<#
+Setup a Python virtual environment for ExtraFabulousReports on Windows.
+Run from a PowerShell prompt.
+#>
+
+Write-Host "Creating virtual environment..."
+py -3 -m venv venv
+
+Write-Host "Activating virtual environment..."
+.\venv\Scripts\Activate.ps1
+
+Write-Host "Installing dependencies..."
+pip install -r requirements.txt
+
+Write-Host "Environment ready. Activate later with '.\\venv\\Scripts\\Activate.ps1'"

--- a/xfabreps_setup_env.sh
+++ b/xfabreps_setup_env.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Prepare a Python virtual environment for ExtraFabulousReports on Linux/Raspberry Pi.
+#
+# This script creates a "venv" directory, activates it and installs all
+# required dependencies. Run it once during initial setup.
+
+set -euo pipefail
+
+python3 -m venv venv                          # Create the virtual environment
+source venv/bin/activate                      # Activate the environment
+pip install -r requirements.txt               # Install dependencies
+printf "Environment ready. Activate with 'source venv/bin/activate'\n"


### PR DESCRIPTION
## Summary
- provide Linux/Raspberry Pi launch script `xfabreps_run_server.sh` with `--port` and `--prod` options
- add Windows PowerShell launch script `xfabreps_run_server.ps1`
- create setup helpers for both platforms and document usage in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68912b7fe7dc83288351121dbbf75b8c