### PR TITLE
Add profile dropdown menu and account screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The project supports both Windows and Linux/Raspberry Pi systems. Small helper s
 2. **Activate the environment and initialise the database**:
    ```bash
    source venv/bin/activate
-   python -m flask --app app.py init-db
+   python -m flask --app xfabreps_app.py init-db
    ```
 3. **Run the server**:
    ```bash
@@ -38,7 +38,7 @@ The project supports both Windows and Linux/Raspberry Pi systems. Small helper s
 2. **Activate the environment and initialise the database**:
    ```powershell
    .\venv\Scripts\Activate.ps1
-   python -m flask --app app.py init-db
+   python -m flask --app xfabreps_app.py init-db
    ```
 3. **Run the server**:
    ```powershell
@@ -78,7 +78,7 @@ python -m pytest
 Generate a LaTeX equation environment from Python code:
 
 ```python
-from app import build_equation
+from xfabreps_app import build_equation
 
 latex = build_equation("E", "mc^2", label="mass_energy")
 print(latex)

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,8 @@
     <title>ExtraFabulousReports</title>
     <!-- Pull Bootstrap CSS from a CDN for a clean, responsive base design -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Include Bootstrap Icons for the profile picture button -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
     <!-- Custom project stylesheet adds small aesthetic flourishes -->
     <link rel="stylesheet" href="{{ url_for('static', filename='custom.css') }}">
     {# Expose administrator-defined colours via CSS variables #}
@@ -48,7 +50,23 @@
                 {% if current_user.is_admin %}
                 <li class="nav-item"><a class="nav-link text-light" href="{{ url_for('edit_style') }}">House Style</a></li>
                 {% endif %}
-                <li class="nav-item"><a class="nav-link text-light" href="{{ url_for('logout') }}">Logout</a></li>
+                {# Profile dropdown menu on the far right for authenticated users #}
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle text-light d-flex align-items-center" href="#" id="profileDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                        <i class="bi bi-person-circle fs-4"></i>
+                    </a>
+                    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileDropdown">
+                        <li><a class="dropdown-item" href="{{ url_for('manage_profiles') }}">Manage Profiles</a></li>
+                        <li><a class="dropdown-item" href="{{ url_for('learning_zone') }}">Learning Zone</a></li>
+                        <li><a class="dropdown-item" href="{{ url_for('my_details') }}">My Details</a></li>
+                        <li><a class="dropdown-item" href="{{ url_for('subscription_details') }}">Subscription Details</a></li>
+                        {% if current_user.is_admin %}
+                        <li><a class="dropdown-item" href="{{ url_for('manage_users') }}">Manage Users</a></li>
+                        {% endif %}
+                        <li><hr class="dropdown-divider"></li>
+                        <li><a class="dropdown-item" href="{{ url_for('logout') }}">Sign out</a></li>
+                    </ul>
+                </li>
                 {% else %}
                 <li class="nav-item"><a class="nav-link text-light" href="{{ url_for('login') }}">Login</a></li>
                 <li class="nav-item"><a class="nav-link text-light" href="{{ url_for('register') }}">Register</a></li>

--- a/templates/learning_zone.html
+++ b/templates/learning_zone.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Learning Zone</h1>
+<p class="lead">Discover tutorials and resources to master ExtraFabulousReports.</p>
+<p>Helpful guides will be listed here soon.</p>
+{% endblock %}

--- a/templates/manage_profiles.html
+++ b/templates/manage_profiles.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Manage Profiles</h1>
+<p class="lead">Use this page to create or edit profiles linked to your account.</p>
+<p>Profile management tools will appear here in future updates.</p>
+{% endblock %}

--- a/templates/manage_users.html
+++ b/templates/manage_users.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Manage Users</h1>
+<p class="lead">Administrators can add or remove user accounts from this area.</p>
+<p>Further user management options will be implemented later.</p>
+{% endblock %}

--- a/templates/my_details.html
+++ b/templates/my_details.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>My Details</h1>
+<p class="lead">Review and update your personal information.</p>
+<p>Editing capabilities will be added in a future release.</p>
+{% endblock %}

--- a/templates/subscription_details.html
+++ b/templates/subscription_details.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Subscription Details</h1>
+<p class="lead">View information about your current subscription.</p>
+<p>Contact support if you need to adjust your plan.</p>
+{% endblock %}

--- a/xfabreps_app.py
+++ b/xfabreps_app.py
@@ -305,6 +305,51 @@ def help_page():
     return render_template('help.html')
 
 # ----------------------------------------------------------------------------
+# Profile and account routes
+# ----------------------------------------------------------------------------
+
+@app.route('/profiles')
+@login_required
+def manage_profiles():
+    """Display profile management interface for the current user."""
+    logging.info("Manage Profiles page accessed by %s", current_user.username)
+    return render_template('manage_profiles.html')
+
+
+@app.route('/learning-zone')
+@login_required
+def learning_zone():
+    """Present learning resources to the user."""
+    logging.info("Learning Zone page accessed by %s", current_user.username)
+    return render_template('learning_zone.html')
+
+
+@app.route('/my-details')
+@login_required
+def my_details():
+    """Show personal account information for the current user."""
+    logging.info("My Details page accessed by %s", current_user.username)
+    return render_template('my_details.html')
+
+
+@app.route('/subscription-details')
+@login_required
+def subscription_details():
+    """Display subscription information for the current user."""
+    logging.info("Subscription Details page accessed by %s", current_user.username)
+    return render_template('subscription_details.html')
+
+
+@app.route('/manage-users')
+@login_required
+def manage_users():
+    """Allow administrators to manage user accounts."""
+    if not current_user.is_admin:
+        abort(403)
+    logging.info("Manage Users page accessed by admin %s", current_user.username)
+    return render_template('manage_users.html')
+
+# ----------------------------------------------------------------------------
 # Utility routes
 # ----------------------------------------------------------------------------
 

--- a/xfabreps_run_server.ps1
+++ b/xfabreps_run_server.ps1
@@ -14,7 +14,8 @@ param(
     [string]$Host = "0.0.0.0"
 )
 
-$cmd = @("python", "app.py", "--host", $Host, "--port", $Port)
+# Build the command using the descriptive application filename.
+$cmd = @("python", "xfabreps_app.py", "--host", $Host, "--port", $Port)
 if ($Prod) { $cmd += "--prod" }
 Write-Host "Starting ExtraFabulousReports with command: $($cmd -join ' ')"
 & $cmd

--- a/xfabreps_run_server.sh
+++ b/xfabreps_run_server.sh
@@ -33,8 +33,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Build the Python command dynamically
-CMD=(python app.py --port "$PORT")
+# Build the Python command dynamically. Use the descriptive module name
+# rather than a generic app.py.
+CMD=(python xfabreps_app.py --port "$PORT")
 if [[ "$USE_PROD" -eq 1 ]]; then
   CMD+=("--prod")
 fi


### PR DESCRIPTION
## Summary
- rename main app script to `xfabreps_app.py` and update documentation and server scripts
- add profile-picture dropdown in the navbar with links to new account pages
- stub out Manage Profiles, Learning Zone, My Details, Subscription Details, and admin-only Manage Users screens

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689207b17fa08328a604b02db11c607f